### PR TITLE
Merge with Jaskaranbir/ttn-grafana-dash-backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Grafana uses [Simple-JSON][2] plugin as its datasource, which gets the data from
 
 * Default username/password for Grafana is `admin` and `admin` respectively.
 
-* Add a new `Simple-Json` type datasource to Grafana, point the URL to `localhost:8080` (for local setup, change as required depending on setup).
+* Add a new `Simple-Json` type datasource to Grafana, point the URL to `http://proxybackend:8080` (for local setup, modify as required depending on setup).
 
 * Add the dashboards/panels.
 

--- a/dashboard-presets/standard-stack.json
+++ b/dashboard-presets/standard-stack.json
@@ -25,7 +25,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "LoraServerProxy",
+      "datasource": "ProxyBackendServer",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -36,13 +36,13 @@
       "id": 3,
       "legend": {
         "alignAsTable": true,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
         "show": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
@@ -109,7 +109,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "LoraServerProxy",
+      "datasource": "ProxyBackendServer",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -120,13 +120,13 @@
       "id": 2,
       "legend": {
         "alignAsTable": true,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
         "show": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
@@ -195,7 +195,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "LoraServerProxy",
+      "datasource": "ProxyBackendServer",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -206,13 +206,13 @@
       "id": 5,
       "legend": {
         "alignAsTable": true,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
         "show": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
@@ -283,7 +283,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "LoraServerProxy",
+      "datasource": "ProxyBackendServer",
       "fill": 1,
       "gridPos": {
         "h": 9,
@@ -294,13 +294,13 @@
       "id": 4,
       "legend": {
         "alignAsTable": true,
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
         "show": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
@@ -371,8 +371,8 @@
     "list": []
   },
   "time": {
-    "from": "now-1m",
-    "to": "now"
+    "from": "now-2m",
+    "to": "now-1m"
   },
   "timepicker": {
     "refresh_intervals": [
@@ -401,6 +401,5 @@
   },
   "timezone": "",
   "title": "Bee-Hive Monitoring Dashboard",
-  "uid": "1azxh5Kmk",
-  "version": 5
+  "uid": "1azxh5Kmk"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,9 @@ services:
       - ./proxybackend:/usr/src/app/
     ports:
       - "8080:8080"
-    network_mode: host
+    networks:
+      - default
+      - dashnet
 
   grafana:
     image: grafana/grafana:latest
@@ -16,7 +18,9 @@ services:
       GF_INSTALL_PLUGINS: grafana-simple-json-datasource
     ports:
       - "3000:3000"
-    network_mode: host
+    networks:
+      - default
+      - dashnet
 
   mongodb:
     image: mongo
@@ -32,7 +36,12 @@ services:
     volumes:
       - "$PWD/mongo-entrypoint/:/docker-entrypoint-initdb.d/"
       - MongoDBVol:/data/db
-    network_mode: host
+    networks:
+      - default
+      - dashnet
+
+networks:
+  dashnet:
 
 volumes:
   MongoDBVol:

--- a/proxybackend/README.md
+++ b/proxybackend/README.md
@@ -7,7 +7,7 @@ This proxybackend is the datasource for Grafana, using MongoDB as its storage-ba
 
 * The configuration can be changed using the [config][1] file.
 
-* By default, the mock data is inserted into MongoDB at intervals of 5 seconds.
+* By default, the mock data is inserted into MongoDB at intervals of 4.5 seconds.
 
   [0]: https://github.com/Jaskaranbir/ttn-grafana-dash-backend/blob/master/proxybackend/dao/dbWriter.js
   [1]: https://github.com/Jaskaranbir/ttn-grafana-dash-backend/blob/master/proxybackend/config.js

--- a/proxybackend/config.js
+++ b/proxybackend/config.js
@@ -20,7 +20,7 @@ module.exports = {
   mongoDb: 'loradb',
 
   // Interval for mock-writer to push data to db
-  mockInsertInterval: 5000, // Millisecond
+  mockInsertInterval: 4500, // Millisecond
   // Port on which the server is run
   port: 8080
 }

--- a/proxybackend/package-lock.json
+++ b/proxybackend/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "docker-node-example",
-  "version": "0.0.0",
+  "name": "proxybackend",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
- Adds dedicated network for containers
- Also changes mock interval to 4.5
- Adds legend-metrics (min, max, avg) to present template